### PR TITLE
Added instant play keybinding

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -1,0 +1,5 @@
+<Bindings>
+  <Binding name="PLAYACTIVEQUEST" default="F6">
+    PlayQuestAudio(nil, true)
+  </Binding>
+</Bindings>

--- a/QuestReaderAddon.lua
+++ b/QuestReaderAddon.lua
@@ -302,7 +302,11 @@ function PlayQuestAudio(textType, skipDelay)
         elseif GossipFrame:IsVisible() then
             textType = "gossip"
         else
-            return
+            if (lastTextType == "") then
+                return
+            else
+                textType = lastTextType
+            end
         end
     end
 
@@ -355,6 +359,10 @@ local function OnPlayerLogout()
     UnmuteDialogChannel()
 end
 
+-- Keybindings
+BINDING_HEADER_QUESTREADERADDON = "Quest Reader Addon"
+BINDING_NAME_PLAYACTIVEQUEST = "Play active quest voiceover"
+
 -- Event Handling for Quest Dialog Events
 local questEventFrame = CreateFrame("Frame")
 questEventFrame:RegisterEvent("QUEST_DETAIL")
@@ -378,8 +386,11 @@ questEventFrame:SetScript("OnEvent", function(self, event, ...)
     elseif event == "QUEST_FINISHED" then
         StopCurrentSound() -- Stop sound when the quest dialog finishes
     end
+
+    lastTextType = textType
 end)
 
+lastTextType = textType
 local logoutFrame = CreateFrame("Frame")
 logoutFrame:RegisterEvent("PLAYER_LOGOUT")
 logoutFrame:SetScript("OnEvent", OnPlayerLogout)

--- a/QuestReaderAddon.toc
+++ b/QuestReaderAddon.toc
@@ -1,8 +1,8 @@
 ## Interface: 110002
 ## Title: Quest Reader Addon
-## Notes: Plays quest audio based on quest ID and text type.
+## Notes: Plays AI-generated quest voiceovers.
 ## Author: clhammer weirdautomation@gmail.com
-## Version: 1.0
+## Version: 1.2
 ## SavedVariables: QuestReaderAddonDB
 
 ## OptionalDeps: QuestReaderPackWW


### PR DESCRIPTION
This adds a new keybinding, defaulted to F6, which you can set in the WoW keybinding system's "Other" tab.

When pressed, the voiceover will begin playback immediately for whichever quest is being displayed. This replaces the play button functionality when using custom quest frame addons.