### PR TITLE
"Read Quest" button on QuestLog Window & toggle to stop Dialogue when closing Quest window

### DIFF
--- a/QuestReaderAddon.lua
+++ b/QuestReaderAddon.lua
@@ -21,6 +21,11 @@ if QuestReaderAddonDB.muteGossip == nil then
 else
     QuestReaderAddonDB.muteGossip = QuestReaderAddonDB.muteGossip
 end
+if QuestReaderAddonDB.stopDialogueOnClose == nil then
+    QuestReaderAddonDB.stopDialogueOnClose = true
+else
+    QuestReaderAddonDB.stopDialogueOnClose = QuestReaderAddonDB.stopDialogueOnClose
+end
 
 local function InitializeAddonDB()
     QuestReaderAddonDB = QuestReaderAddonDB or {}
@@ -40,6 +45,11 @@ local function InitializeAddonDB()
         QuestReaderAddonDB.muteGossip = true
     else
         QuestReaderAddonDB.muteGossip = QuestReaderAddonDB.muteGossip
+    end
+    if QuestReaderAddonDB.stopDialogueOnClose == nil then
+        QuestReaderAddonDB.stopDialogueOnClose = true
+    else
+        QuestReaderAddonDB.stopDialogueOnClose = QuestReaderAddonDB.stopDialogueOnClose
     end
     QuestReaderAddonDB.IsPaused = false
     QuestReaderAddonDB.IsSoundPaused = false
@@ -397,8 +407,8 @@ questEventFrame:SetScript("OnEvent", function(self, event, ...)
 
     if textType ~= "" and QuestReaderAddonDB.autoPlayEnabled then
         PlayQuestAudio(textType)  -- Call PlayQuestAudio with textType from event
-    elseif event == "QUEST_FINISHED" then
-        -- StopCurrentSound() -- Stop sound when the quest dialog finishes
+    elseif event == "QUEST_FINISHED" and QuestReaderAddonDB.stopDialogueOnClose then
+        StopCurrentSound() -- Stop sound when the quest dialog finishes
     end
 
     lastTextType = textType

--- a/QuestReaderAddon.lua
+++ b/QuestReaderAddon.lua
@@ -398,7 +398,7 @@ questEventFrame:SetScript("OnEvent", function(self, event, ...)
     if textType ~= "" and QuestReaderAddonDB.autoPlayEnabled then
         PlayQuestAudio(textType)  -- Call PlayQuestAudio with textType from event
     elseif event == "QUEST_FINISHED" then
-        StopCurrentSound() -- Stop sound when the quest dialog finishes
+        -- StopCurrentSound() -- Stop sound when the quest dialog finishes
     end
 
     lastTextType = textType

--- a/QuestReaderAddon.lua
+++ b/QuestReaderAddon.lua
@@ -141,6 +141,19 @@ local function InitializeQuestFrameButtons()
     questFrameButton:SetScript("OnClick", function()
         PlayQuestAudio(nil, true)
     end)
+
+    -- Create the button for the Quest Log (QuestMapFrame)
+    if QuestMapFrame and QuestMapFrame.DetailsFrame then
+        local questLogButton = CreateFrame("Button", "QuestLogReaderButtonFrame", QuestMapFrame.DetailsFrame, "UIPanelButtonTemplate")
+        questLogButton:SetSize(90, 21)
+        questLogButton:SetText("Read Quest")
+        -- Position it at the top left of the details frame, offset to the right to be next to Back button
+        questLogButton:SetPoint("TOPLEFT", QuestMapFrame.DetailsFrame, "TOPLEFT", 105, -10)
+
+        questLogButton:SetScript("OnClick", function()
+            PlayQuestAudio("description", true)
+        end)
+    end
 end
 
 loadingFrame:SetScript("OnEvent", function(self, event, loadedAddonName)
@@ -284,7 +297,14 @@ function StopCurrentSound()
 end
 
 function PlayQuestAudio(textType, skipDelay)
-    questID = GetQuestID()
+    -- Get quest ID from Quest Log if it's open, otherwise from quest giver
+    local questID
+    if QuestMapFrame and QuestMapFrame:IsVisible() then
+        questID = C_QuestLog.GetSelectedQuest()
+    else
+        questID = GetQuestID()
+    end
+
     if not textType then
         -- Initialize textType based on visible panels
         if QuestFrameDetailPanel:IsVisible() then

--- a/QuestReaderAddon_Settings.lua
+++ b/QuestReaderAddon_Settings.lua
@@ -54,6 +54,7 @@ function QuestReader:CreateSettings()
         { option = "autoPlayEnabled", detail = "Auto-play quest audio" },
         { option = "showMinimapButton", detail = "Show minimap button" },
         { option = "muteGossip", detail = "Mute greetings (instant autoplay)" },
+        { option = "stopDialogueOnClose", detail = "Stop Dialogue when closing Quest window" },
     }
 
     for _, keyInfo in ipairs(settingsInfo) do


### PR DESCRIPTION
As I suggested in https://github.com/clhammer89/QuestReaderAddon/issues/42 I have now added a "Read Quest" button in the QuestLog on the Map. I've used it for a while and works great.
I also don't like that the addon is modifying my dialogue audio bus and had issues where it was not properly restored in some edgecases. I'm aware that this is necessary to mute gossip, but I don't need that feature, so I added a toggle to disable this behaviour. :)

Awesome addon, I can't believe how good the voices sound and how close they match the actual voice actress of each NPC. How did you pull that off? Doesn't that require training a voice model for each npc? Seems like a ton of work, but it's super cool to use. Really enhances my questing experience! <3